### PR TITLE
Disable the static linking

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,9 +3,3 @@ cargo-features = ["profile-rustflags"]
 [workspace]
 resolver = "2"
 members = ["crates/*"]
-
-[profile.dev.package.humanode-distribution]
-rustflags = ["-C", "target-feature=+crt-static"]
-
-[profile.release.package.humanode-distribution]
-rustflags = ["-C", "target-feature=+crt-static"]


### PR DESCRIPTION
Ah, yeah, static linking of glibc is broken. We link everything else statically, so we're good.